### PR TITLE
Fix for price-indexer in Magento 1.7

### DIFF
--- a/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Configurable.php
+++ b/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Configurable.php
@@ -84,6 +84,8 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Eav_Mysq
             'max_price'         => new Zend_Db_Expr('pi.final_price'),
             'tier_price'        => new Zend_Db_Expr('pi.tier_price'),
             'base_tier'         => new Zend_Db_Expr('pi.tier_price'),
+            'group_price'       => new Zend_Db_Expr('pi.group_price'),
+            'base_group_price'  => new Zend_Db_Expr('pi.base_group_price'),
         ));
 
 
@@ -126,6 +128,8 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Eav_Mysq
             'max_price'     => new Zend_Db_Expr('MAX(inner.max_price)'),
             'tier_price',
             'base_tier',
+            'group_price',
+            'base_group_price',
             #'child_entity_id'
         ));
 

--- a/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Configurable.php
+++ b/app/code/community/OrganicInternet/SimpleConfigurableProducts/Catalog/Model/Resource/Eav/Mysql4/Product/Indexer/Price/Configurable.php
@@ -85,7 +85,7 @@ class OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Eav_Mysq
             'tier_price'        => new Zend_Db_Expr('pi.tier_price'),
             'base_tier'         => new Zend_Db_Expr('pi.tier_price'),
             'group_price'       => new Zend_Db_Expr('pi.group_price'),
-            'base_group_price'  => new Zend_Db_Expr('pi.base_group_price'),
+            'base_group_price'  => new Zend_Db_Expr('pi.group_price'),
         ));
 
 


### PR DESCRIPTION
Added columns group_price and base_group_price to column-list to fix the price indexing error in Magento 1.7.x
