### PR TITLE
Fixing ambiguous/inconsistent indentation

### DIFF
--- a/skin/frontend/base/default/js/scp_product_extension.js
+++ b/skin/frontend/base/default/js/scp_product_extension.js
@@ -348,10 +348,11 @@ Product.OptionsPrice.prototype.reloadPriceLabels = function(productPriceIsKnown)
     var priceSpanId = 'configurable-price-from-' + this.productId;
     var duplicatePriceSpanId = priceSpanId + this.duplicateIdSuffix;
 
-    if($(priceSpanId) && $(priceSpanId).select('span.configurable-price-from-label'))
+    if($(priceSpanId) && $(priceSpanId).select('span.configurable-price-from-label')) {
         $(priceSpanId).select('span.configurable-price-from-label').each(function(label) {
-        label.innerHTML = priceFromLabel;
-    });
+            label.innerHTML = priceFromLabel;
+        });
+    }
 
     if ($(duplicatePriceSpanId) && $(duplicatePriceSpanId).select('span.configurable-price-from-label')) {
         $(duplicatePriceSpanId).select('span.configurable-price-from-label').each(function(label) {


### PR DESCRIPTION
This is a pretty trivial change but makes this block of code easier to read and parallel with the next block. Previously it was indented to look like an if block, but actually it was structured as a single-line if statement with a lambda function block inside the statement. This makes the if statement a block of its own with the lambda clearly nested inside that.
