### PR TITLE
Add options in Backend / Order detail page / Email

### DIFF
--- a/app/code/community/OrganicInternet/SimpleConfigurableProducts/Sales/Model/Order/Item.php
+++ b/app/code/community/OrganicInternet/SimpleConfigurableProducts/Sales/Model/Order/Item.php
@@ -1,0 +1,37 @@
+<?php
+
+class OrganicInternet_SimpleConfigurableProducts_Sales_Model_Order_Item extends Mage_Sales_Model_Order_Item {
+	
+	/**
+	 * Get product options array
+	 *
+	 * @return array
+	 */
+	public function getProductOptions() {
+		if ($options = $this->_getData('product_options')) {
+			$options = unserialize($options);
+			
+			// If options not found, fetch them from super attribute
+			if(!isset($options['attributes_info']) && isset($options['info_buyRequest']['super_attribute'])){
+				$storeId = Mage::app()->getStore()->getId();
+				$info = array();
+				foreach($options['info_buyRequest']['super_attribute'] as $k => $v){
+					$attributeModel = Mage::getModel('eav/entity_attribute')->load($k);
+					
+					$info[] = array(
+						'label' => $attributeModel->getStoreLabel($storeId),
+						'value' => $attributeModel->getSource()->getOptionText($v)
+					);
+				}
+				
+				if(!empty($info)) {
+					$options['attributes_info'] = $info;
+				}
+			}
+			
+			return $options;
+		}
+		return array();
+	}
+
+}

--- a/app/code/community/OrganicInternet/SimpleConfigurableProducts/etc/config.xml
+++ b/app/code/community/OrganicInternet/SimpleConfigurableProducts/etc/config.xml
@@ -55,6 +55,11 @@
                     <product_indexer_price>OrganicInternet_SimpleConfigurableProducts_Catalog_Model_Resource_Eav_Mysql4_Product_Indexer_Price</product_indexer_price>
                 </rewrite>
             </catalog_resource_eav_mysql4>
+            <sales>
+                <rewrite>
+                    <order_item>OrganicInternet_SimpleConfigurableProducts_Sales_Model_Order_Item</order_item>
+                </rewrite>
+            </sales>
         </models>
         <blocks>
             <adminhtml>


### PR DESCRIPTION
Added a rewrite on Sales Item model to show options on Invoice, Backend order detail page, Frontend order detail page and Email. The options are fetched from the super attributes that are part of the serialized data.